### PR TITLE
feat(edn-editor): Add support for sequential, set, and, multi schema types

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -13,6 +13,6 @@
                                io.github.robertluo/rich-comment-tests {:mvn/version "1.1.78"}
                                philoskim/debux                        {:mvn/version "0.9.1"}}}
            :nrepl {:jvm-opts ["-Djdk.attach.allowAttachSelf"]
-                   :main-opts ["-m" "nrepl.cmdline" "--port" "7888"]}}
-          :test {:exec-fn   com.mjdowney.rich-comment-tests.test-runner/run-tests-in-file-tree!
-                 :exec-args {:dirs #{"src"}}}}
+                   :main-opts ["-m" "nrepl.cmdline" "--port" "7888"]}
+           :test {:exec-fn   com.mjdowney.rich-comment-tests.test-runner/run-tests-in-file-tree!
+                  :exec-args {:dirs #{"src"}}}}}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
         "echarts": "^5.6.0"
     },
     "devDependencies": {
-        "webpack": "^5.101.0",
+        "webpack": "^5.104.1",
         "webpack-cli": "^6.0.1"
     }
 }

--- a/portfolio/dashcraft/scenes.cljs
+++ b/portfolio/dashcraft/scenes.cljs
@@ -7,8 +7,7 @@
    [robertluo.dashcraft.edn-editor :as ee]
    [robertluo.dashcraft.form :as form]
    [robertluo.dashcraft.loading :as loading]
-   [robertluo.dashcraft.error-aware :as error-aware]
-   [replicant.dom :as r]))
+   [robertluo.dashcraft.error-aware :as error-aware]))
 
 (defscene simple-chart
   :params (atom {:columns [:product "2015" "2016"],
@@ -104,6 +103,24 @@
                      [:vector :string]]]
      [:metadata [:map-of :keyword :string]]
      [:foo [:tuple :int :string :boolean]]]
+    ::ee/value @state
+    ::ee/on-change (fn [v] (prn (reset! state v)))}])
+
+(defscene edn-editor
+  :params (atom {:type :human
+                 :name "bob"
+                 :pet '("dog" "cat")
+                 :favourite-color #{"red" "green" "blue"}})
+  [state]
+  [ee/editor
+   {::ee/schema
+    [:multi {:dispatch :type}
+     [:sized [:map [:type [:= :sized]]
+              [:size [:and :int [:fn pos-int?]]]]]
+     [:human [:map [:type [:= :human]]
+              [:name :string]
+              [:pet [:sequential :string]]
+              [:favourite-color [:set :string]]]]]
     ::ee/value @state
     ::ee/on-change (fn [v] (prn (reset! state v)))}])
 

--- a/portfolio/dashcraft/scenes.cljs
+++ b/portfolio/dashcraft/scenes.cljs
@@ -115,9 +115,12 @@
   [ee/editor
    {::ee/schema
     [:multi {:dispatch :type}
-     [:sized [:map [:type [:= :sized]]
+     [:malli.core/default [:map [:type [:enum :sized :human]]]]
+     [:sized [:map
+              [:type [:= :sized]]
               [:size [:and :int [:fn pos-int?]]]]]
-     [:human [:map [:type [:= :human]]
+     [:human [:map
+              [:type [:= :human]]
               [:name :string]
               [:pet [:sequential :string]]
               [:favourite-color [:set :string]]]]]

--- a/portfolio/dashcraft/scenes.cljs
+++ b/portfolio/dashcraft/scenes.cljs
@@ -168,8 +168,8 @@
    {:config
     {:css-paths ["/css/chart.css" "/css/data_table.css"
                  "/css/edn_editor.css" "/css/form.css"
-                 "/css/loading.css" "/css/error_aware.css"]}
-    :viewport/defaults
-    {:background/background-color "#fdeddd"}}))
+                 "/css/loading.css" "/css/error_aware.css"]
+     :viewport/defaults
+     {:background/background-color "#fdeddd"}}}))
 
 (main)

--- a/resources/public/css/edn_editor.css
+++ b/resources/public/css/edn_editor.css
@@ -19,6 +19,10 @@
     border-radius: 0.1em;
 }
 
+.malli-editor-btn span:hover {
+    background: #9b9ab5;
+}
+
 .malli-editor {
     font-family: monospace;
     color: #151640;
@@ -32,6 +36,11 @@
     border: 1px solid #b9b8cb;
 }
 
+.malli-editor input:focus {
+    outline: none;
+    border-color: #8887a3;
+}
+
 .malli-editor-invalid {
     background: #fc9483;
 }
@@ -39,6 +48,11 @@
 .malli-editor select {
     font-family: inherit;
     font-size: inherit;
+}
+
+.malli-editor select:focus {
+    outline: none;
+    border-color: #8887a3;
 }
 
 .malli-editor-example h2 {
@@ -66,4 +80,14 @@
 .malli-editor-add-keys {
     display: flex;
     flex-flow: row wrap;
+}
+
+.malli-editor-multi-select {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+}
+
+.malli-editor-dispatch-key {
+    color: #8f8dac;
 }

--- a/resources/public/css/edn_editor.css
+++ b/resources/public/css/edn_editor.css
@@ -6,6 +6,7 @@
 .malli-editor-extra-keys-title {
     color: #8f8dac;
     display: flex;
+    flex-wrap: wrap;
 }
 
 .malli-editor-btn span {

--- a/resources/public/css/edn_editor.css
+++ b/resources/public/css/edn_editor.css
@@ -2,8 +2,10 @@
 
 .malli-editor-or-choices,
 .malli-editor-orn-choices,
+.malli-editor-multi-choices,
 .malli-editor-extra-keys-title {
     color: #8f8dac;
+    display: flex;
 }
 
 .malli-editor-btn a:link,
@@ -30,7 +32,7 @@
 }
 
 .malli-editor-invalid {
-    background: #fc9483
+    background: #fc9483;
 }
 
 .malli-editor select {

--- a/resources/public/css/edn_editor.css
+++ b/resources/public/css/edn_editor.css
@@ -43,3 +43,26 @@
 .malli-editor-example h2 {
     font-family: monospace;
 }
+
+.malli-editor-maybe,
+.malli-editor-brackets,
+.malli-editor-key-value,
+.malli-editor-set-elements,
+.malli-editor-vector-elements,
+.malli-editor-sequential-elements,
+.malli-editor-extra-keys-elements {
+    display: flex;
+}
+
+.malli-editor-bracket-close {
+    align-self: flex-end;
+}
+
+.malli-editor-value {
+    margin-left: 0.5em;
+}
+
+.malli-editor-add-keys {
+    display: flex;
+    flex-flow: row wrap;
+}

--- a/resources/public/css/edn_editor.css
+++ b/resources/public/css/edn_editor.css
@@ -142,7 +142,7 @@
     gap: 4px;
 }
 
-.malli-editor-union-select {
+.malli-editor-multi-select {
     display: flex;
     align-items: center;
     gap: 0.5em;

--- a/resources/public/css/edn_editor.css
+++ b/resources/public/css/edn_editor.css
@@ -8,8 +8,8 @@
     display: flex;
 }
 
-.malli-editor-btn a:link,
-.malli-editor-btn a:visited {
+.malli-editor-btn span {
+    cursor: pointer;
     color: white;
     text-decoration: none;
     padding-left: 0.5em;

--- a/resources/public/css/edn_editor.css
+++ b/resources/public/css/edn_editor.css
@@ -1,88 +1,148 @@
-/* reference styles for edn-editor */
+/* ===========================================
+   EDN Editor Styles
+   =========================================== */
 
-.malli-editor-or-choices,
-.malli-editor-orn-choices,
-.malli-editor-multi-choices,
-.malli-editor-extra-keys-title {
-    color: #8f8dac;
-    display: flex;
-    flex-wrap: wrap;
+/* --- Main Container --- */
+.malli-editor {
+    font-family: monospace;
+    color: #151640;
+    line-height: 1.8;
 }
 
+/* --- Form Controls: Inputs --- */
+.malli-editor input {
+    font-family: inherit;
+    font-size: inherit;
+    color: inherit;
+    border: 1px solid #b9b8cb;
+    border-radius: 3px;
+    padding: 2px 4px;
+    transition: border-color 0.15s ease;
+}
+
+.malli-editor input:focus {
+    outline: none;
+    border-color: #8887a3;
+    box-shadow: 0 0 0 2px rgba(136, 135, 163, 0.15);
+}
+
+/* --- Form Controls: Selects --- */
+.malli-editor select {
+    font-family: inherit;
+    font-size: inherit;
+    border: 1px solid #b9b8cb;
+    border-radius: 3px;
+    padding: 2px 4px;
+    cursor: pointer;
+    transition: border-color 0.15s ease;
+}
+
+.malli-editor select:focus {
+    outline: none;
+    border-color: #8887a3;
+    box-shadow: 0 0 0 2px rgba(136, 135, 163, 0.15);
+}
+
+/* --- Form Controls: Checkboxes --- */
+.malli-editor input[type="checkbox"] {
+    cursor: pointer;
+}
+
+/* --- Validation State --- */
+.malli-editor-invalid {
+    background: #fc9483;
+    border-color: #e57373 !important;
+}
+
+/* --- Buttons (+/-) --- */
 .malli-editor-btn span {
     cursor: pointer;
     color: white;
-    text-decoration: none;
-    padding-left: 0.5em;
-    padding-right: 0.5em;
+    padding: 1px 6px;
     background: #b9b8cb;
-    border-radius: 0.1em;
+    border-radius: 3px;
+    font-size: 0.9em;
+    transition: background 0.15s ease;
 }
 
 .malli-editor-btn span:hover {
     background: #9b9ab5;
 }
 
-.malli-editor {
-    font-family: monospace;
-    color: #151640;
-    line-height: 2;
-}
-
-.malli-editor input {
-    font-family: inherit;
-    font-size: inherit;
-    color: inherit;
-    border: 1px solid #b9b8cb;
-}
-
-.malli-editor input:focus {
-    outline: none;
-    border-color: #8887a3;
-}
-
-.malli-editor-invalid {
-    background: #fc9483;
-}
-
-.malli-editor select {
-    font-family: inherit;
-    font-size: inherit;
-}
-
-.malli-editor select:focus {
-    outline: none;
-    border-color: #8887a3;
-}
-
-.malli-editor-example h2 {
-    font-family: monospace;
-}
-
-.malli-editor-maybe,
-.malli-editor-brackets,
-.malli-editor-key-value,
-.malli-editor-set-elements,
-.malli-editor-vector-elements,
-.malli-editor-sequential-elements,
-.malli-editor-extra-keys-elements {
+/* --- Bracket Containers --- */
+.malli-editor-brackets {
     display: flex;
+    align-items: flex-start;
+}
+
+.malli-editor-bracket-open,
+.malli-editor-bracket-close {
+    color: #6b7280;
 }
 
 .malli-editor-bracket-close {
     align-self: flex-end;
 }
 
+/* --- Map Key-Value Pairs --- */
+.malli-editor-key-value {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+}
+
 .malli-editor-value {
     margin-left: 0.5em;
 }
 
+/* --- Collection Elements --- */
+.malli-editor-vector-elements,
+.malli-editor-set-elements,
+.malli-editor-sequential-elements,
+.malli-editor-extra-keys-elements {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+}
+
+/* --- Maybe (Optional) --- */
+.malli-editor-maybe {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+}
+
+/* --- Add Keys Section --- */
 .malli-editor-add-keys {
     display: flex;
     flex-flow: row wrap;
+    gap: 4px;
+    margin-top: 2px;
 }
 
-.malli-editor-multi-select {
+/* --- Extra Keys Section --- */
+.malli-editor-extra-keys {
+    margin-top: 4px;
+    padding-top: 4px;
+    border-top: 1px dashed #d1d5db;
+    opacity: 0.8;
+}
+
+.malli-editor-extra-keys-title {
+    color: #8f8dac;
+    font-size: 0.9em;
+}
+
+/* --- Union Types (or/orn/multi) --- */
+.malli-editor-or,
+.malli-editor-orn,
+.malli-editor-multi {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.malli-editor-union-select {
     display: flex;
     align-items: center;
     gap: 0.5em;

--- a/src/robertluo/dashcraft/data_table.cljc
+++ b/src/robertluo/dashcraft/data_table.cljc
@@ -42,8 +42,7 @@ returns `data` specified by `grouping` spec:
            {:name "John" :sex :male :balance -456 :age 45}]}
    {:column :sex :aggregations [[:balance] [:age]]}) ; =>>
   {:columns #((set %) ::group) ;; new column added
-   :rows [{::group :male, :children #(= 2 (count %)), :balance 1322986, :age 68}]}
-  )
+   :rows [{::group :male, :children #(= 2 (count %)), :balance 1322986, :age 68}]})
 
 (defn ^:no-doc switch-sorting
   [sorting column]
@@ -51,7 +50,7 @@ returns `data` specified by `grouping` spec:
       (assoc :column column)
       (update :order (fn [o] (case o :asc :desc :desc nil :asc)))))
 
-(defalias 
+(defalias
   ^{:doc "
 A table header component.
 Special attributes:
@@ -68,8 +67,8 @@ Can have children which inherites `::column`
    [:span (or (label-of column) " ")]
    (map #(hiccup/update-attrs % assoc ::column column) children)])
 
-(defalias 
-  ^{:doc 
+(defalias
+  ^{:doc
     "
 A sort button for `th`, generating sorting preference from the user.
 Special attributes:
@@ -81,7 +80,7 @@ Special attributes:
    - `order` the order of the sort, `:asc`, `:desc` and nil
    - `sortable` a predict accept a column and returns true if the column support sorting
 "}
-  sort-button 
+  sort-button
   [{::keys [column on-sort sorting] :as attrs}]
   (let [{sort-clm :column order :order sortable :sortable :or {sortable (constantly true)}} sorting
         sortable? (sortable column)]
@@ -92,7 +91,7 @@ Special attributes:
        sortable? " ↕️"
        :else " ")]))
 
-(defalias 
+(defalias
   ^{:doc "
 Display cell of data table.
         
@@ -105,8 +104,8 @@ special attributes:
 Can have children who inherit `::column` and `::cell`.
       "}
   td
-  [{::keys [column cell label-of class-of] 
-    :or {class-of (constantly []) 
+  [{::keys [column cell label-of class-of]
+    :or {class-of (constantly [])
          label-of (fn [_ v] (str v))}
     :as attrs}
    children]
@@ -122,24 +121,25 @@ Can have children who inherit `::column` and `::cell`.
    (sort-rows rows sorting nil))
   ([rows sorting drill-down]
    (let [{sort-clm :column order :order} sorting
-         f #(sort-by sort-clm (if (= order :asc) < >) %)]
-     (cond->> rows 
+         key-accessor (fn [m]
+                        (get m sort-clm))
+         f #(sort-by key-accessor (if (= order :asc) < >) %)]
+     (cond->> rows
        (and sort-clm order) f
        drill-down (map (fn [r] (update r drill-down sort-rows sorting drill-down)))))))
 
 ^:rct/test
 (comment
-  (sort-rows 
+  (sort-rows
    [{::group :male, :children [{:name "Robert", :sex :male, :age 23, :balance 1323442}
                                {:name "John", :sex :male, :balance -456, :age 45}], :balance 1322986, :age 68}
     {::group :female, :children [{:name "Jane", :sex :female, :age 15, :balance 61923}], :balance 61923, :age 15}]
    {:column :balance :order :desc}
    :children) ;=>>
   [{::group :male :children [{:name "Robert"} {:name "John"}]}
-   {::group :female :children [{:name "Jane"}]}] 
-  )
+   {::group :female :children [{:name "Jane"}]}])
 
-(defalias 
+(defalias
   ^{:doc "
 Data table component.
 
@@ -154,7 +154,7 @@ Chidlren:
   - a table-header default to `th`
   - a table-cell default to `td`
 "}
-  table 
+  table
   [{::keys [data drill-down] :as attrs}
    [table-header table-cell]]
   (let [{:keys [columns rows]} data]

--- a/src/robertluo/dashcraft/edn_editor.cljc
+++ b/src/robertluo/dashcraft/edn_editor.cljc
@@ -47,6 +47,9 @@
 (defmethod default-value :orn [schema]
   (default-value (last (first (m/children schema)))))
 
+(defmethod default-value :multi [schema]
+  (default-value (last (first (m/children schema)))))
+
 (defmethod default-value :enum [schema]
   (first (m/children schema)))
 

--- a/src/robertluo/dashcraft/edn_editor.cljc
+++ b/src/robertluo/dashcraft/edn_editor.cljc
@@ -380,7 +380,8 @@
 (defmethod edit :multi [schema value on-change]
   (let [nom (name (gensym "multi-schema"))
         dispatch-key (:dispatch (m/properties schema))
-        children (for [[dispatch _ schema] (m/children schema)]
+        children (for [[dispatch _ schema] (m/children schema)
+                       :when (not= ::m/default dispatch)]
                    {:dispatch dispatch
                     :schema schema
                     :label (pr-str dispatch)

--- a/src/robertluo/dashcraft/edn_editor.cljc
+++ b/src/robertluo/dashcraft/edn_editor.cljc
@@ -15,7 +15,7 @@
 
 (defmulti default-value (fn [schema]
                           (when schema
-                            (:type (m/ast schema)))))
+                            (m/type schema))))
 
 (defmethod default-value :default    [_] nil)
 (defmethod default-value :string     [_] "")
@@ -72,7 +72,7 @@
 
 (defmulti edit (fn [schema _value _on-change]
                  (when schema
-                   (:type (m/ast schema))))) ;; TODO is there a simpler way to check the type?
+                   (m/type schema))))
 
 (defmethod edit :default [schema value _on-change]
   [:div
@@ -114,7 +114,7 @@
   [:div.malli-editor-enum
    (into [:select {:on {:change #(on-change (-> % .-target .-value edn/read-string))}}]
          (for [v (m/children schema)]
-           [:option {:selected (= value v)}
+           [:option {:value (pr-str v) :selected (= value v)}
             (pr-str v)]))])
 
 (defn bracket [open close contents]
@@ -153,7 +153,7 @@
               [:div
                (for [k present-keys]
                  (let [[_ properties value-schema] (mu/find schema k)]
-                   [:div.malli-editor-key-value
+                   [:div.malli-editor-key-value {:replicant/key k}
                     [:div.malli-editor-key (pr-str k)]
                     (when (:optional properties)
                       (btn-minus #(on-change (dissoc value k))))
@@ -377,20 +377,22 @@
        (edit (:schema selected) value on-change))]))
 
 (defmethod edit :multi [schema value on-change]
-  (let [dispatch-fn (:dispatch (m/properties schema))
-        current-dispatch (dispatch-fn value)
+  (let [dispatch-key (:dispatch (m/properties schema))
+        current-dispatch (dispatch-key value)
         matched-dispatch (if (some #(= current-dispatch (first %)) (m/children schema))
                            current-dispatch
                            (ffirst (m/children schema)))]
     [:div.malli-editor-multi
-     [:select
-      {:on {:change (fn [e]
-                      (let [selected-dispatch (-> e .-target .-value edn/read-string)
-                            value-schema (mu/get schema selected-dispatch)]
-                        (on-change (default-value value-schema))))}}
-      (for [[dispatch _ _] (m/children schema)]
-        [:option {:value (pr-str dispatch) :selected (= dispatch matched-dispatch)}
-         (pr-str dispatch)])]
+     [:div.malli-editor-multi-select
+      [:span.malli-editor-dispatch-key (pr-str dispatch-key)]
+      [:select
+       {:on {:change (fn [e]
+                       (let [selected-dispatch (-> e .-target .-value edn/read-string)
+                             value-schema (mu/get schema selected-dispatch)]
+                         (on-change (default-value value-schema))))}}
+       (for [[dispatch _ _] (m/children schema)]
+         [:option {:value (pr-str dispatch) :selected (= dispatch matched-dispatch)}
+          (pr-str dispatch)])]]
      (edit (mu/get schema matched-dispatch) value on-change)]))
 
 (defmethod edit :schema [schema value on-change]

--- a/src/robertluo/dashcraft/edn_editor.cljc
+++ b/src/robertluo/dashcraft/edn_editor.cljc
@@ -136,10 +136,9 @@
 
 (defmethod edit :maybe [schema value on-change]
   (let [child (first (m/children schema))]
-    [:div.malli-editor-maybe
-     (if (nil? value)
-       (btn-plus #(on-change (default-value child)))
-       [:div (btn-minus #(on-change nil)) (edit child value on-change)])]))
+    (if (nil? value)
+      [:div.malli-editor-maybe (btn-plus #(on-change (default-value child))) [:div (pr-str value)]]
+      [:div.malli-editor-maybe (btn-minus #(on-change nil)) (edit child value on-change)])))
 
 (defmethod edit :map [schema value on-change]
   (let [map-schema (m/children schema)
@@ -299,7 +298,7 @@
    (bracket "[" "]"
             [:div
              (map-indexed (fn [i v]
-                            [:div.malli-editor-vector-elements
+                            [:div.malli-editor-vector-elements {:replicant/key i}
                              (btn-minus #(on-change (dissocv value i)))
                              (edit (mu/get schema i) v #(on-change (assoc value i %)))])
                           value)
@@ -311,7 +310,7 @@
             (if (list? value) ")" "]")
             [:div
              (map-indexed (fn [i v]
-                            [:div.malli-editor-sequential-elements
+                            [:div.malli-editor-sequential-elements {:replicant/key i}
                              (btn-minus #(on-change (sequential-remove-at value i)))
                              (edit (mu/get schema i) v #(on-change (sequential-update-at value i %)))])
                           value)
@@ -322,7 +321,7 @@
    (bracket "#{" "}"
             [:div
              (map (fn [v]
-                    [:div.malli-editor-set-elements
+                    [:div.malli-editor-set-elements {:replicant/key v}
                      (btn-minus #(on-change (disj value v)))
                      (edit (mu/get schema 0) v #(on-change (-> value (disj v) (conj %))))])
                   value)

--- a/src/robertluo/dashcraft/edn_editor.cljc
+++ b/src/robertluo/dashcraft/edn_editor.cljc
@@ -202,6 +202,33 @@
     (list? coll)
     (keep-indexed #(when-not (= idx %1) %2) coll)))
 
+^:rct/test
+(comment
+  (sequential-remove-at [1 2 3 4] 1)
+  ;=> [1 3 4]
+
+  (sequential-remove-at [1 2 3 4] 0)
+  ;=> [2 3 4]
+
+  (sequential-remove-at [1 2 3 4] 3)
+  ;=> [1 2 3]
+
+  (sequential-remove-at [1] 0)
+  ;=> []
+
+  (sequential-remove-at '(1 2 3 4) 1)
+  ;=> '(1 3 4)
+
+  (sequential-remove-at '(1 2 3 4) 0)
+  ;=> '(2 3 4)
+
+  (sequential-remove-at '(1 2 3 4) 3)
+  ;=> '(1 2 3)
+
+  (sequential-remove-at '(1) 0)
+  ;=> '()
+  )
+
 (defn sequential-update-at
   "Updates an item at index `idx` with value `val` in a sequential
   collection `coll`, preserving the original collection type."
@@ -213,6 +240,27 @@
     (list? coll)
     (apply list (assoc (vec coll) idx val))))
 
+^:rct/test
+(comment
+  (sequential-update-at [1 2 3] 1 :x)
+  ;=> [1 :x 3]
+
+  (sequential-update-at [1 2 3] 0 :x)
+  ;=> [:x 2 3]
+
+  (sequential-update-at [1 2 3] 2 :x)
+  ;=> [1 2 :x]
+
+  (sequential-update-at '(1 2 3) 1 :x)
+  ;=> '(1 :x 3)
+
+  (sequential-update-at '(1 2 3) 0 :x)
+  ;=> '(:x 2 3)
+
+  (sequential-update-at '(1 2 3) 2 :x)
+  ;=> '(1 2 :x)
+  )
+
 (defn sequential-add
   "Adds an item `val` to the sequential collection `coll`,
   preserving the original collection type."
@@ -220,6 +268,21 @@
   (cond
     (vector? coll) (conj coll val)
     (list? coll) (concat coll (list val))))
+
+^:rct/test
+(comment
+  (sequential-add [1 2] 3)
+  ;=> [1 2 3]
+
+  (sequential-add [] 1)
+  ;=> [1]
+
+  (sequential-add '(1 2) 3)
+  ;=> '(1 2 3)
+
+  (sequential-add '() 1)
+  ;=> '(1)
+  )
 
 (defmethod edit :tuple [schema value on-change]
   [:div.malli-editor-tuple

--- a/src/robertluo/dashcraft/edn_editor.cljc
+++ b/src/robertluo/dashcraft/edn_editor.cljc
@@ -379,22 +379,24 @@
 
 (defmethod edit :multi [schema value on-change]
   (let [nom (name (gensym "multi-schema"))
-        dispatch-key (:dispatch (m/properties schema))
-        children (for [[dispatch _ schema] (m/children schema)
-                       :when (not= ::m/default dispatch)]
+        dispatch-fn (:dispatch (m/properties schema))
+        children (for [[dispatch _ schema] (m/children schema)]
                    {:dispatch dispatch
                     :schema schema
                     :label (pr-str dispatch)
-                    :selected (= dispatch (dispatch-key value))})
-        selected (first (filter :selected children))]
+                    :valid (m/validate schema value)
+                    :selected (= dispatch (dispatch-fn value))})
+        selected (or
+                  (first (filter :selected children))
+                  (first (filter :valid children)))]
     [:div.malli-editor-multi
      (into [:div.malli-editor-multi-choices ";;"]
            (for [c children]
              (let [id (str nom "--" (:label c))]
                [:div
                 [:input {:type :radio :id id :name nom
-                         :checked (:selected c)
-                         :on {:change (if (:selected c)
+                         :checked (= selected c)
+                         :on {:change (if (= selected c)
                                         (constantly nil)
                                         #(on-change (default-value (:schema c))))}}]
                 [:label {:for id} (:label c)]])))

--- a/src/robertluo/dashcraft/edn_editor.cljc
+++ b/src/robertluo/dashcraft/edn_editor.cljc
@@ -4,6 +4,7 @@
   Copy from https://github.com/opqdonut/malli-edn-editor/blob/main/src/editor.cljs
   Many thanks to @opqdonut"
   (:require
+   [clojure.edn :as edn]
    [malli.core :as m]
    [malli.transform :as mt]
    [malli.util :as mu]
@@ -16,13 +17,17 @@
                           (when schema
                             (:type (m/ast schema)))))
 
-(defmethod default-value :default [_] nil)
-(defmethod default-value :string  [_] "")
-(defmethod default-value :keyword [_] (->> (rand-int 1000) (str "keyword") keyword))
-(defmethod default-value :vector  [_] [])
-(defmethod default-value :boolean [_] (even? (rand-int 2)))
-(defmethod default-value :int     [_] (rand-int 1000))
-(defmethod default-value :double  [_] (rand))
+(defmethod default-value :default    [_] nil)
+(defmethod default-value :string     [_] "")
+(defmethod default-value :keyword    [_] (->> (rand-int 1000) (str "keyword") keyword))
+(defmethod default-value :vector     [_] [])
+(defmethod default-value :sequential [_] [])
+(defmethod default-value :set        [_] #{})
+(defmethod default-value :boolean    [_] (even? (rand-int 2)))
+(defmethod default-value :int        [_] (rand-int 1000))
+(defmethod default-value :double     [_] (rand))
+
+(defmethod default-value := [schema] (first (m/children schema)))
 
 (defmethod default-value :map [schema]
   (into {}
@@ -32,6 +37,9 @@
               (m/children schema))))
 
 (defmethod default-value :map-of [_] {})
+
+(defmethod default-value :and [schema]
+  (default-value (first (m/children schema))))
 
 (defmethod default-value :or [schema]
   (default-value (first (m/children schema))))
@@ -67,13 +75,16 @@
    [:p (pr-str (m/ast schema))]
    [:p (pr-str value)]])
 
- ;; TODO validation errors
+;; TODO validation errors
 (defn input-field [schema value on-change]
   (let [valid? (m/validate schema value)]
     [:input {:type :text
              :class (when-not valid? :malli-editor-invalid)
              :default-value (m/encode schema value mt/string-transformer)
              :on {:change #(on-change (m/decode schema (-> % .-target .-value) mt/string-transformer))}}]))
+
+(defmethod edit := [_ value _]
+  [:div (pr-str value)])
 
 (defmethod edit :string [schema value on-change]
   [:div.malli-editor-string "\"" (input-field schema value on-change) "\""])
@@ -96,7 +107,7 @@
 
 (defmethod edit :enum [schema value on-change]
   [:div.malli-editor-enum
-   (into [:select {:on {:change #(on-change (-> % .-target .-value))}}]
+   (into [:select {:on {:change #(on-change (-> % .-target .-value edn/read-string))}}]
          (for [v (m/children schema)]
            [:option {:selected (= value v)}
             (pr-str v)]))])
@@ -177,6 +188,36 @@
 (defn- dissocv [v i]
   (into (subvec v 0 i) (subvec v (inc i))))
 
+(defn sequential-remove-at
+  "Removes an item at index `idx` from a sequential collection `coll`,
+  preserving the original collection type."
+  [coll idx]
+  (cond
+    (vector? coll)
+    (dissocv coll idx)
+
+    (list? coll)
+    (keep-indexed #(when-not (= idx %1) %2) coll)))
+
+(defn sequential-update-at
+  "Updates an item at index `idx` with value `val` in a sequential
+  collection `coll`, preserving the original collection type."
+  [coll idx val]
+  (cond
+    (vector? coll)
+    (assoc coll idx val)
+
+    (list? coll)
+    (apply list (assoc (vec coll) idx val))))
+
+(defn sequential-add
+  "Adds an item `val` to the sequential collection `coll`,
+  preserving the original collection type."
+  [coll val]
+  (cond
+    (vector? coll) (conj coll val)
+    (list? coll) (concat coll (list val))))
+
 (defmethod edit :tuple [schema value on-change]
   [:div.malli-editor-tuple
    (bracket "[" "]"
@@ -195,6 +236,36 @@
                              (edit (mu/get schema i) v #(on-change (assoc value i %)))])
                           value)
              (btn-plus #(on-change (conj (or value []) (default-value (mu/get schema 0)))))])])
+
+(defmethod edit :sequential [schema value on-change]
+  [:div.malli-editor-sequential
+   (bracket (if (list? value) "(" "[")
+            (if (list? value) ")" "]")
+            [:div
+             (map-indexed (fn [i v]
+                            [:div {:style {:display :flex}}
+                             (btn-minus #(on-change (sequential-remove-at value i)))
+                             (edit (mu/get schema i) v #(on-change (sequential-update-at value i %)))])
+                          value)
+             (btn-plus #(on-change (sequential-add (or value []) (default-value (mu/get schema 0)))))])])
+
+(defmethod edit :set [schema value on-change]
+  [:div.malli-editor-set
+   (bracket "#{" "}"
+            [:div
+             (map (fn [v]
+                    [:div {:style {:display :flex}}
+                     (btn-minus #(on-change (disj value v)))
+                     (edit (mu/get schema 0) v #(on-change (-> value (disj v) (conj %))))])
+                  value)
+             (btn-plus #(on-change (conj (or value #{}) (default-value (mu/get schema 0)))))])])
+
+(defmethod edit :and [schema value on-change]
+  (let [primary-schema (first (m/children schema))
+        valid? (m/validate schema value)]
+    [:div.malli-editor-and
+     {:class (when-not valid? :malli-editor-invalid)}
+     (edit primary-schema value on-change)]))
 
 (defmethod edit :orn [schema value on-change]
   (let [nom (name (gensym "orn-schema"))
@@ -224,21 +295,44 @@
                    {:schema c
                     :valid (m/validate c value)
                     :label (pr-str (:type (m/ast c)))})
-        first-valid (first (filter :valid children))]
+        selected (or (first (filter :valid children))
+                     (first children))]
     [:div.malli-editor-or
      (into [:div.malli-editor-or-choices ";;"]
            (for [c children]
              (let [id (str nom "--" (:label c))]
                [:div
                 [:input {:type :radio :id id :name nom
-                         :checked (:valid c)
-                         :on {:change (if (:valid c)
+                         :checked (= selected c)
+                         :on {:change (if (= selected c)
                                         (constantly nil) ;; silence reagent warning by always having a callback
                                         #(on-change (default-value (:schema c))))}}]
                 [:label {:for id} (:label c)]])))
-     (if first-valid
-       (edit (:schema first-valid) value on-change)
-       [:p (pr-str value)])]))
+     (when selected
+       (edit (:schema selected) value on-change))]))
+
+(defmethod edit :multi [schema value on-change]
+  (let [nom (name (gensym "multi-schema"))
+        dispatch-key (:dispatch (m/properties schema))
+        children (for [[dispatch _ schema] (m/children schema)]
+                   {:dispatch dispatch
+                    :schema schema
+                    :label (pr-str dispatch)
+                    :selected (= dispatch (dispatch-key value))})
+        selected (first (filter :selected children))]
+    [:div.malli-editor-multi
+     (into [:div.malli-editor-multi-choices ";;"]
+           (for [c children]
+             (let [id (str nom "--" (:label c))]
+               [:div
+                [:input {:type :radio :id id :name nom
+                         :checked (:selected c)
+                         :on {:change (if (:selected c)
+                                        (constantly nil)
+                                        #(on-change (default-value (:schema c))))}}]
+                [:label {:for id} (:label c)]])))
+     (when selected
+       (edit (:schema selected) value on-change))]))
 
 (defmethod edit :schema [schema value on-change]
   (edit (m/deref schema) value on-change))

--- a/src/robertluo/dashcraft/edn_editor.cljc
+++ b/src/robertluo/dashcraft/edn_editor.cljc
@@ -338,8 +338,6 @@
   (let [nom (name (gensym "orn-schema"))
         p (m/parse schema value)
         matched-case (if (= :malli.core/invalid p)
-                       ;; just pick the first case if input is invalid
-                       ;; TODO figure out what to do here 
                        (->> schema m/entries first key)
                        (:key p))]
     [:div.malli-editor-orn
@@ -351,7 +349,7 @@
                 [:input {:type :radio :id id :name nom
                          :checked (= k matched-case)
                          :on {:change (if (= k matched-case)
-                                        (constantly nil) ;; silence react warning by always having a callback
+                                        (constantly nil)
                                         #(on-change (default-value value-schema)))}}]
                 [:label {:for id} label]])))
      (edit (mu/get schema matched-case) value on-change)]))
@@ -372,37 +370,28 @@
                 [:input {:type :radio :id id :name nom
                          :checked (= selected c)
                          :on {:change (if (= selected c)
-                                        (constantly nil) ;; silence reagent warning by always having a callback
+                                        (constantly nil)
                                         #(on-change (default-value (:schema c))))}}]
                 [:label {:for id} (:label c)]])))
      (when selected
        (edit (:schema selected) value on-change))]))
 
 (defmethod edit :multi [schema value on-change]
-  (let [nom (name (gensym "multi-schema"))
-        dispatch-fn (:dispatch (m/properties schema))
-        children (for [[dispatch _ schema] (m/children schema)]
-                   {:dispatch dispatch
-                    :schema schema
-                    :label (pr-str dispatch)
-                    :valid (m/validate schema value)
-                    :selected (= dispatch (dispatch-fn value))})
-        selected (or
-                  (first (filter :selected children))
-                  (first (filter :valid children)))]
+  (let [dispatch-fn (:dispatch (m/properties schema))
+        current-dispatch (dispatch-fn value)
+        matched-dispatch (if (some #(= current-dispatch (first %)) (m/children schema))
+                           current-dispatch
+                           (ffirst (m/children schema)))]
     [:div.malli-editor-multi
-     (into [:div.malli-editor-multi-choices ";;"]
-           (for [c children]
-             (let [id (str nom "--" (:label c))]
-               [:div
-                [:input {:type :radio :id id :name nom
-                         :checked (= selected c)
-                         :on {:change (if (= selected c)
-                                        (constantly nil)
-                                        #(on-change (default-value (:schema c))))}}]
-                [:label {:for id} (:label c)]])))
-     (when selected
-       (edit (:schema selected) value on-change))]))
+     [:select
+      {:on {:change (fn [e]
+                      (let [selected-dispatch (-> e .-target .-value edn/read-string)
+                            value-schema (mu/get schema selected-dispatch)]
+                        (on-change (default-value value-schema))))}}
+      (for [[dispatch _ _] (m/children schema)]
+        [:option {:value (pr-str dispatch) :selected (= dispatch matched-dispatch)}
+         (pr-str dispatch)])]
+     (edit (mu/get schema matched-dispatch) value on-change)]))
 
 (defmethod edit :schema [schema value on-change]
   (edit (m/deref schema) value on-change))

--- a/src/robertluo/dashcraft/edn_editor.cljc
+++ b/src/robertluo/dashcraft/edn_editor.cljc
@@ -201,7 +201,7 @@
     (dissocv coll idx)
 
     (list? coll)
-    (keep-indexed #(when-not (= idx %1) %2) coll)))
+    (apply list (keep-indexed #(when-not (= idx %1) %2) coll))))
 
 ^:rct/test
 (comment
@@ -268,7 +268,7 @@
   [coll val]
   (cond
     (vector? coll) (conj coll val)
-    (list? coll) (concat coll (list val))))
+    (list? coll) (apply list (concat coll (list val)))))
 
 ^:rct/test
 (comment
@@ -356,7 +356,7 @@
                                         {:idx i
                                          :schema c
                                          :valid (m/validate c value)
-                                         :label (pr-str (:type (m/ast c)))})
+                                         :label (pr-str (m/type c))})
                                       children)
         selected (or (first (filter :valid indexed-children))
                      (first indexed-children))]

--- a/src/robertluo/dashcraft/edn_editor.cljc
+++ b/src/robertluo/dashcraft/edn_editor.cljc
@@ -335,44 +335,40 @@
      (edit primary-schema value on-change)]))
 
 (defmethod edit :orn [schema value on-change]
-  (let [nom (name (gensym "orn-schema"))
-        p (m/parse schema value)
+  (let [p (m/parse schema value)
         matched-case (if (= :malli.core/invalid p)
                        (->> schema m/entries first key)
                        (:key p))]
     [:div.malli-editor-orn
-     (into [:div.malli-editor-orn-choices ";;"]
-           (for [[k _p value-schema] (m/children schema)]
-             (let [label (pr-str k)
-                   id (str nom "--" label)]
-               [:div
-                [:input {:type :radio :id id :name nom
-                         :checked (= k matched-case)
-                         :on {:change (if (= k matched-case)
-                                        (constantly nil)
-                                        #(on-change (default-value value-schema)))}}]
-                [:label {:for id} label]])))
+     [:select
+      {:on {:change (fn [e]
+                      (let [selected-key (-> e .-target .-value edn/read-string)
+                            value-schema (mu/get schema selected-key)]
+                        (on-change (default-value value-schema))))}}
+      (for [[k _ _] (m/children schema)]
+        [:option {:value (pr-str k) :selected (= k matched-case)}
+         (pr-str k)])]
      (edit (mu/get schema matched-case) value on-change)]))
 
 (defmethod edit :or [schema value on-change]
-  (let [nom (name (gensym "or-schema"))
-        children (for [c (m/children schema)]
-                   {:schema c
-                    :valid (m/validate c value)
-                    :label (pr-str (:type (m/ast c)))})
-        selected (or (first (filter :valid children))
-                     (first children))]
+  (let [children (m/children schema)
+        indexed-children (map-indexed (fn [i c]
+                                        {:idx i
+                                         :schema c
+                                         :valid (m/validate c value)
+                                         :label (pr-str (:type (m/ast c)))})
+                                      children)
+        selected (or (first (filter :valid indexed-children))
+                     (first indexed-children))]
     [:div.malli-editor-or
-     (into [:div.malli-editor-or-choices ";;"]
-           (for [c children]
-             (let [id (str nom "--" (:label c))]
-               [:div
-                [:input {:type :radio :id id :name nom
-                         :checked (= selected c)
-                         :on {:change (if (= selected c)
-                                        (constantly nil)
-                                        #(on-change (default-value (:schema c))))}}]
-                [:label {:for id} (:label c)]])))
+     [:select.malli-editor-or-select
+      {:on {:change (fn [e]
+                      (let [selected-idx (-> e .-target .-value edn/read-string)
+                            value-schema (nth children selected-idx)]
+                        (on-change (default-value value-schema))))}}
+      (for [{:keys [idx label]} indexed-children]
+        [:option {:value idx :selected (= idx (:idx selected))}
+         label])]
      (when selected
        (edit (:schema selected) value on-change))]))
 

--- a/src/robertluo/dashcraft/edn_editor.cljc
+++ b/src/robertluo/dashcraft/edn_editor.cljc
@@ -123,7 +123,7 @@
 
 (defn btn [text on-click]
   [:div.malli-editor-btn
-   [:a {:href "#" :on {:click on-click}}
+   [:span {:on {:click on-click}}
     text]])
 
 (defn btn-plus [on-click]

--- a/src/robertluo/dashcraft/edn_editor.cljc
+++ b/src/robertluo/dashcraft/edn_editor.cljc
@@ -29,6 +29,8 @@
 
 (defmethod default-value := [schema] (first (m/children schema)))
 
+(defmethod default-value :maybe [schema] (default-value (first (m/children schema))))
+
 (defmethod default-value :map [schema]
   (into {}
         (keep (fn [[k properties value]]
@@ -116,10 +118,10 @@
             (pr-str v)]))])
 
 (defn bracket [open close contents]
-  [:div.malli-editor-brackets {:style {:display :flex}}
+  [:div.malli-editor-brackets
    [:div.malli-editor-bracket-open open]
    [:div.malli-editor-bracket-contents contents]
-   [:div.malli-editor-bracket-close {:style {:align-self :flex-end}} close]])
+   [:div.malli-editor-bracket-close close]])
 
 (defn btn [text on-click]
   [:div.malli-editor-btn
@@ -134,7 +136,7 @@
 
 (defmethod edit :maybe [schema value on-change]
   (let [child (first (m/children schema))]
-    [:div.malli-editor-maybe {:style {:display :flex}}
+    [:div.malli-editor-maybe
      (if (nil? value)
        (btn-plus #(on-change (default-value child)))
        [:div (btn-minus #(on-change nil)) (edit child value on-change)])]))
@@ -152,14 +154,14 @@
               [:div
                (for [k present-keys]
                  (let [[_ properties value-schema] (mu/find schema k)]
-                   [:div.malli-editor-key-value {:style {:display :flex}}
+                   [:div.malli-editor-key-value
                     [:div.malli-editor-key (pr-str k)]
                     (when (:optional properties)
                       (btn-minus #(on-change (dissoc value k))))
                     (when-let [[_ v] (find value k)]
-                      [:div.malli-editor-value {:style {:margin-left "0.5em"}}
+                      [:div.malli-editor-value
                        (edit value-schema v #(on-change (assoc value k %)))])]))
-               [:div.malli-editor-add-keys {:style {:display :flex :flex-flow "row wrap"}}
+               [:div.malli-editor-add-keys
                 (for [k missing-keys]
                   (let [value-schema (mu/get schema k)]
                     (btn (str "<+" (pr-str k) ">") #(on-change (assoc value k (default-value value-schema))))))]
@@ -167,10 +169,10 @@
                  [:div.malli-editor-extra-keys
                   [:div.malli-editor-extra-keys-title ";; extra keys:"]
                   (for [[k v] extra-value]
-                    [:div {:style {:display :flex}}
+                    [:div.malli-editor-extra-keys-elements
                      [:div.malli-editor-key (pr-str k)]
                      (btn-minus #(on-change (dissoc value k)))
-                     [:div.malli-editor-value {:style {:margin-left "0.5em"}}
+                     [:div.malli-editor-value
                       (pr-str v)]])])])]))
 
 (defmethod edit :map-of [schema value on-change]
@@ -179,11 +181,11 @@
      (bracket "{" "}"
               [:div
                (for [[k v] value]
-                 [:div.malli-editor-key-value {:style {:display :flex}}
+                 [:div.malli-editor-key-value
                   (btn-minus #(on-change (dissoc value k)))
                   [:div.malli-editor-key
                    (edit key-schema k #(on-change (-> value (dissoc k) (assoc % v))))]
-                  [:div.malli-editor-value {:style {:margin-left "0.5em"}}
+                  [:div.malli-editor-value
                    (edit value-schema v #(on-change (assoc value k %)))]])
                ;; TODO what to do when key is already taken?
                (btn-plus #(on-change (assoc value (default-value key-schema) (default-value value-schema))))])]))
@@ -297,7 +299,7 @@
    (bracket "[" "]"
             [:div
              (map-indexed (fn [i v]
-                            [:div {:style {:display :flex}}
+                            [:div.malli-editor-vector-elements
                              (btn-minus #(on-change (dissocv value i)))
                              (edit (mu/get schema i) v #(on-change (assoc value i %)))])
                           value)
@@ -309,7 +311,7 @@
             (if (list? value) ")" "]")
             [:div
              (map-indexed (fn [i v]
-                            [:div {:style {:display :flex}}
+                            [:div.malli-editor-sequential-elements
                              (btn-minus #(on-change (sequential-remove-at value i)))
                              (edit (mu/get schema i) v #(on-change (sequential-update-at value i %)))])
                           value)
@@ -320,7 +322,7 @@
    (bracket "#{" "}"
             [:div
              (map (fn [v]
-                    [:div {:style {:display :flex}}
+                    [:div.malli-editor-set-elements
                      (btn-minus #(on-change (disj value v)))
                      (edit (mu/get schema 0) v #(on-change (-> value (disj v) (conj %))))])
                   value)


### PR DESCRIPTION
## Summary
- Add editor support for `:sequential`, `:set`, `:and`, and `:multi` malli schema types with proper collection-type-preserving operations
- Replace radio buttons with `<select>` dropdowns for `:or`, `:orn`, and `:multi` dispatch selection
- Move inline styles to CSS and improve editor styling (hover effects, focus states, layout via CSS classes)
- Fix `sort-rows` to use `get` for column key accessor to support vector keys

## Details
- New helper functions (`sequential-remove-at`, `sequential-update-at`, `sequential-add`) preserve original collection type (vector vs list)
- Use `m/type` instead of `(:type (m/ast schema))` for schema type dispatch
- Replace `<a>` tags with `<span>` for editor buttons (avoids navigation side-effects)
- Improve `:maybe` editor layout
